### PR TITLE
Added filter section for code coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,14 @@
          stopOnFailure="false"
          syntaxCheck="false"
 >
+    <filter>
+        <blacklist>
+            <directory suffix=".php">.</directory>
+        </blacklist>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>


### PR DESCRIPTION
I don't know if this might be related to the problems you were just tweeting about, but I noticed this and figured I'd send a PR.

If you run phpunit without the filter in place, it's going to gather coverage metrics for everything in your `vendor` directory, which you obviously don't want.

Compare:

``` bash
# see https://ocramius.github.io/blog/automated-code-coverage-check-for-github-pull-requests-with-travis/
# for coverage-checker.php source

# before my PR
mmoussa@daetu ~/projects/miscellaneous/faktory ±master⚡ » php ../coverage-checker.php build/logs/clover.xml 100
Code coverage is 28.369370834011%, which is below the accepted 100%

# after my PR
mmoussa@daetu ~/projects/miscellaneous/faktory ±master⚡ » php ../coverage-checker.php build/logs/clover.xml 100
Code coverage is 93.536121673004%, which is below the accepted 100%
```

You can also notice it in the test run time:

``` bash
# before my PR
mmoussa@daetu ~/projects/miscellaneous/faktory ±master⚡ » phpunit
PHPUnit 4.4.1 by Sebastian Bergmann.

Configuration read from /Users/mmoussa/projects/miscellaneous/faktory/phpunit.xml

............................................................

Time: 6.58 seconds, Memory: 27.00Mb

OK (60 tests, 191 assertions)

Generating code coverage report in Clover XML format ... done

# after my PR
mmoussa@daetu ~/projects/miscellaneous/faktory ±master⚡ » phpunit
PHPUnit 4.4.1 by Sebastian Bergmann.

Configuration read from /Users/mmoussa/projects/miscellaneous/faktory/phpunit.xml

............................................................

Time: 3 seconds, Memory: 16.00Mb

OK (60 tests, 191 assertions)

Generating code coverage report in Clover XML format ... done
```

It takes more than twice as long to run the tests because it's gathering coverage info on much more code.

I hope this helps, but if not, at least you'll have an accurate total coverage percentage. :)
